### PR TITLE
Update Demo + K nearest 2/3/19

### DIFF
--- a/Demo + K nearest
+++ b/Demo + K nearest
@@ -21,14 +21,16 @@ from sklearn import tree
 
 # Split the data into test and training (30% for test)
 
+from sklearn.model_selection import train_test_split
 
-X_test= X[:1]
-X=[1:]
-Y_test= Y[:1]
-Y=[1:]
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.3) # tuy nhiên với số mẫu ít vầy thì không nên tách ra thì hơn...
+
+
 
 #Initiate the classifier Tree
-clf = tree.DecisionTreeClassifier() #function of tree?
+clf = tree.DecisionTreeClassifier() #function of tree? đây là một function viết bằng nền tảng thuật toán tree, 
+                                    #tuy nhiên cần có các mẫu luyện để có được tham số còn thiếu trước khi được một 
+                                    #mô hình 'tree' hoàn chỉnh (và đây là lý do sao ta học toán)
 
 #Tree training
 clf = clf.fit(X, Y)


### PR DESCRIPTION
X_test= X[:1]
X=[1:]
Y_test= Y[:1]
Y=[1:]
đoạn trên nếu c để ý cả phần sau thì không dùng bất kì biến nào được khai báo ở trên, chưa kể X=[:1] bị sai syntax. Do đó t xóa đi...
Nếu c định dùng 1 trong mấy điểm đã được dùng để train mô hình (ở bước fit) để kiểm tra (bước predict) thì sẽ không được minh bạch vì cái mô hình đấy fit vào cái điểm c test qua bước train r.